### PR TITLE
-Using Set<Model> function we can fix the nullable warning of the DBS…

### DIFF
--- a/Data/DatabaseContext.cs
+++ b/Data/DatabaseContext.cs
@@ -4,29 +4,27 @@ namespace Data;
 
 public class DatabaseContext : Microsoft.EntityFrameworkCore.DbContext
 {
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 	public DatabaseContext
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 		(Microsoft.EntityFrameworkCore.DbContextOptions<DatabaseContext> options) : base(options: options)
 	{
 		Database.EnsureCreated();
 	}
 
-	public Microsoft.EntityFrameworkCore.DbSet<Domain.Role> Roles { get; set; }
+	public Microsoft.EntityFrameworkCore.DbSet<Domain.Role> Roles => Set<Domain.Role>();
 
-	public Microsoft.EntityFrameworkCore.DbSet<Domain.User> Users { get; set; }
+	public Microsoft.EntityFrameworkCore.DbSet<Domain.User> Users => Set<Domain.User>();
 
-	public Microsoft.EntityFrameworkCore.DbSet<Domain.Page> Pages { get; set; }
+	public Microsoft.EntityFrameworkCore.DbSet<Domain.Page> Pages => Set<Domain.Page>();
 
-	public Microsoft.EntityFrameworkCore.DbSet<Domain.LoginLog> LoginLogs { get; set; }
+	public Microsoft.EntityFrameworkCore.DbSet<Domain.LoginLog> LoginLogs => Set<Domain.LoginLog>();
 
-	public Microsoft.EntityFrameworkCore.DbSet<Domain.MenuItem> MenuItems { get; set; }
+	public Microsoft.EntityFrameworkCore.DbSet<Domain.MenuItem> MenuItems => Set<Domain.MenuItem>();
 
-	public Microsoft.EntityFrameworkCore.DbSet<Domain.Permission> Permissions { get; set; }
+	public Microsoft.EntityFrameworkCore.DbSet<Domain.Permission> Permissions => Set<Domain.Permission>();
 
-	public Microsoft.EntityFrameworkCore.DbSet<Domain.PageCategory> PageCategories { get; set; }
+	public Microsoft.EntityFrameworkCore.DbSet<Domain.PageCategory> PageCategories => Set<Domain.PageCategory>();
 
-	public Microsoft.EntityFrameworkCore.DbSet<Domain.ApplicationHandler> ApplicationHandlers { get; set; }
+	public Microsoft.EntityFrameworkCore.DbSet<Domain.ApplicationHandler> ApplicationHandlers => Set<Domain.ApplicationHandler>();
 
 	protected override void OnConfiguring
 		(Microsoft.EntityFrameworkCore.DbContextOptionsBuilder optionsBuilder)

--- a/Server/Pages/Account/Register.cshtml.cs
+++ b/Server/Pages/Account/Register.cshtml.cs
@@ -81,12 +81,12 @@ namespace Server.Pages.Security
 				//}
 
 				//// **************************************************
-				//Domain.User user = new()
+				//Domain.User user = new(fixedEmailAddress)
 				//{
 				//	Username = fixedUsername,
 				//	//RoleId = DefaultRoleId,
 				//	EmailAddress = fixedEmailAddress,
-				//	Password = Dtat.Security.Cryptography.GetSha256(text: ViewModel.Password),
+				//	Password = Dtat.Security.Hashing.GetSha256(text: ViewModel.Password),
 				//};
 
 				//await DatabaseContext.AddAsync(entity: user);

--- a/Server/Pages/Account/Register.cshtml.cs
+++ b/Server/Pages/Account/Register.cshtml.cs
@@ -36,10 +36,10 @@ namespace Server.Pages.Security
 			}
 
 			// **************************************************
-			//string? fixedUsername = Infrastructure.Utility
+			//string? fixedUsername = Dtat.Utility
 			//	.RemoveSpacesAndMakeTextCaseInsensitive(text: ViewModel.Username);
 
-			//string? fixedEmailAddress = Infrastructure.Utility
+			//string? fixedEmailAddress = Dtat.Utility
 			//	.RemoveSpacesAndMakeTextCaseInsensitive(text: ViewModel.EmailAddress);
 			// **************************************************
 
@@ -53,8 +53,9 @@ namespace Server.Pages.Security
 				//bool isEmailAddressFound =
 				//	await DatabaseContext.Users
 				//	.Where(current => current.EmailAddress == fixedEmailAddress)
-				//	.Where(current => current.IsEmailAddressVerified.HasValue && current.IsEmailAddressVerified.Value)
-				//	.Where(current => current.IsDeleted == false)
+				//	.Where(current => current.IsEmailAddressVerified && current.IsEmailAddressVerified)
+				//	// User no longer has a IsDeleted property.
+				//	//.Where(current => current.IsDeleted == false)
 				//	.AnyAsync();
 
 				//// **************************************************


### PR DESCRIPTION
Due to Microsoft documentation [here](https://learn.microsoft.com/en-us/ef/core/miscellaneous/nullable-reference-types#dbcontext-and-dbset) we can use Set to fix nullable instead of disabling warnings.